### PR TITLE
Correct NullReferenceException when From address not explicitly set

### DIFF
--- a/src/ActionMailerNext/Implementations/SMTP/SmtpMailSender.cs
+++ b/src/ActionMailerNext/Implementations/SMTP/SmtpMailSender.cs
@@ -55,7 +55,7 @@ namespace ActionMailerNext.Implementations.SMTP
                 message.ReplyToList.Add(mail.ReplyTo[i]);
 
             // From is optional because it could be set in <mailSettings>
-            if (!String.IsNullOrWhiteSpace(mail.From.Address))
+            if (mail.From != null && !String.IsNullOrWhiteSpace(mail.From.Address))
                 message.From = new MailAddress(mail.From.Address, mail.From.DisplayName);
 
 


### PR DESCRIPTION
Workaround:  set the from address explicitly from the web.config on controller initialize:

        protected override void Initialize(System.Web.Routing.RequestContext requestContext)
        {
            base.Initialize(requestContext);

            var section = ConfigurationManager.GetSection("system.net/mailSettings/smtp") as SmtpSection;
            MailAttributes.From = new System.Net.Mail.MailAddress(section.From);
        }