### PR TITLE
Fix send async. Add subject encoding settings.

### DIFF
--- a/src/ActionMailerNext/Implementations/SMTP/SmtpMailSender.cs
+++ b/src/ActionMailerNext/Implementations/SMTP/SmtpMailSender.cs
@@ -139,7 +139,7 @@ namespace ActionMailerNext.Implementations.SMTP
             var mail = GenerateProspectiveMailMessage(mailAttributes);
             try
             {
-                _client.SendMailAsync(mail);
+                await _client.SendMailAsync(mail);
                 response.AddRange(mail.To.Select(mailAddr => new SmtpMailResponse()
                 {
                     Email = mailAddr.Address, 

--- a/src/ActionMailerNext/Implementations/SMTP/SmtpMailSender.cs
+++ b/src/ActionMailerNext/Implementations/SMTP/SmtpMailSender.cs
@@ -60,8 +60,10 @@ namespace ActionMailerNext.Implementations.SMTP
 
 
             message.Subject = mail.Subject;
-            message.SubjectEncoding = Encoding.GetEncoding("ISO-8859-1"); //https://connect.microsoft.com/VisualStudio/feedback/details/785710/mailmessage-subject-incorrectly-encoded-in-utf-8-base64
-            message.BodyEncoding = Encoding.UTF8;
+
+            //https://connect.microsoft.com/VisualStudio/feedback/details/785710/mailmessage-subject-incorrectly-encoded-in-utf-8-base64
+            message.SubjectEncoding = mail.SubjectEncoding ?? Encoding.GetEncoding("ISO-8859-1");
+            message.BodyEncoding = mail.MessageEncoding ?? Encoding.UTF8;
             message.Priority = mail.Priority;
 
             foreach (var kvp in mail.Headers)

--- a/src/ActionMailerNext/MailAttributes.cs
+++ b/src/ActionMailerNext/MailAttributes.cs
@@ -76,7 +76,12 @@ namespace ActionMailerNext
         ///     The subject line of the email.
         /// </summary>
         public string Subject { get; set; }
-
+        /// <summary>
+        ///     Gets or sets the default subject encoding when delivering mail.
+        ///     <para>Default ISO-8859-1. for latin charsets. <see cref="https://connect.microsoft.com/VisualStudio/feedback/details/785710/mailmessage-subject-incorrectly-encoded-in-utf-8-base64"/></para>
+        ///     Use Utf-8 for Cyrillic charsets.
+        /// </summary>
+        public Encoding SubjectEncoding { get; set; }
         /// <summary>
         ///     The Priority of the email.
         /// </summary>


### PR DESCRIPTION
For Cyrilic charsets encoding ISO-8859-1 doesn't work. 
Work well Utf-8.
I add setting for mail subject encoding in mail attributes.