### PR TITLE
[MAR-12945] Fix if.and and if.or helpers

### DIFF
--- a/src/ActionMailerNext.SendInBlue/ActionMailerNext.SendInBlue.csproj
+++ b/src/ActionMailerNext.SendInBlue/ActionMailerNext.SendInBlue.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>netstandard2.0</TargetFramework>
-	<Version>1.0.4</Version>
-	<Authors>crossvertise GmbH</Authors>
+	  <TargetFramework>netstandard2.0</TargetFramework>
+	  <Version>1.0.4</Version>
+	  <Authors>crossvertise GmbH</Authors>
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="sib_api_v3_sdk" Version="3.3.0" />
-	<PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+	  <PackageReference Include="sib_api_v3_sdk" Version="3.3.0" />
+	  <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-	<ProjectReference Include="..\ActionMailerNext\ActionMailerNext.csproj" />
+	  <ProjectReference Include="..\ActionMailerNext\ActionMailerNext.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ActionMailerNext.SendInBlue/ActionMailerNext.SendInBlue.csproj
+++ b/src/ActionMailerNext.SendInBlue/ActionMailerNext.SendInBlue.csproj
@@ -1,17 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<Version>1.0.3-alpha</Version>
-	</PropertyGroup>
+  <PropertyGroup>
+	<TargetFramework>netstandard2.0</TargetFramework>
+	<Version>1.0.4</Version>
+	<Authors>crossvertise GmbH</Authors>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="sib_api_v3_sdk" Version="3.3.0" />
-		<PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-	</ItemGroup>
+  <ItemGroup>
+	<PackageReference Include="sib_api_v3_sdk" Version="3.3.0" />
+	<PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\ActionMailerNext\ActionMailerNext.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+	<ProjectReference Include="..\ActionMailerNext\ActionMailerNext.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/ActionMailerNext.SendInBlue/SendInBlueMailSender.cs
+++ b/src/ActionMailerNext.SendInBlue/SendInBlueMailSender.cs
@@ -118,7 +118,7 @@
             }
             catch (Exception ex)
             {
-                throw new SendInBlueException(ex.Message, ex.InnerException);
+                throw new SendInBlueException(ex.Message, ex);
             }
         }
 
@@ -154,7 +154,7 @@
             }
             catch (Exception ex)
             {
-                throw new SendInBlueException(ex.Message, ex.InnerException);
+                throw new SendInBlueException(ex.Message, ex);
             }
         }
 

--- a/src/ActionMailerNext.Standalone/ActionMailerNext.Standalone.csproj
+++ b/src/ActionMailerNext.Standalone/ActionMailerNext.Standalone.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.5.15-alpha</Version>
-    <Authors>ayman</Authors>
-    <Company>Crossvertise</Company>
+    <Version>3.5.16</Version>
+    <Authors>crossvertise GmbH</Authors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ActionMailerNext.Standalone/Helpers/HandlebarsHelpers.cs
+++ b/src/ActionMailerNext.Standalone/Helpers/HandlebarsHelpers.cs
@@ -826,7 +826,7 @@
         }
 
         /// <summary>
-        /// {{#if.or bool1 bool2 bool3}}{{else}}{{/if.and}}
+        /// {{#if.or bool1 bool2 bool3}}{{else}}{{/if.or}}
         /// Same like the standard if helper but it takes an infinite number of arguments and it will evaluate them with an 'Or' between each of them
         /// It also evaluates null objects, empty lists or strings as false
         /// It doesn't alter the scope.
@@ -1150,7 +1150,7 @@
 
         private bool IsTrue(object obj)
         {
-            if (obj == null)
+            if (obj == null || obj is UndefinedBindingResult)
             {
                 return false;
             }

--- a/src/ActionMailerNext/ActionMailerNext.csproj
+++ b/src/ActionMailerNext/ActionMailerNext.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.5.2-alpha</Version>
-    <Authors>ayman</Authors>
-    <Company>Crossvertise</Company>
+    <Version>3.5.3</Version>
+	<Authors>crossvertise GmbH</Authors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* The "if.and" and "if.or" helpers were not considering undefined properties and returning true in those situations.
* Improved the exception handling of SendInBlueMailSender. In Raygun we cannot se the whole exception, just the inner exception, which is empty most of the time.